### PR TITLE
Cached initEnvironment in module.

### DIFF
--- a/client.go
+++ b/client.go
@@ -195,7 +195,7 @@ func (m *MqttAPI) client(c sobek.ConstructorCall) *sobek.Object {
 		clientConf.clientCertKeyPath = clientCertKeyPathValue.String()
 	}
 	labels := getLabels(c.Argument(9), rt)
-	metrics, err := registerMetrics(m.vu, labels)
+	metrics, err := registerMetrics(m.initEnvironment, labels)
 	if err != nil {
 		common.Throw(m.vu.Runtime(), err)
 	}

--- a/module.go
+++ b/module.go
@@ -1,6 +1,7 @@
 package mqtt
 
 import (
+	"go.k6.io/k6/js/common"
 	"go.k6.io/k6/js/modules"
 )
 
@@ -13,13 +14,14 @@ func init() {
 
 // MqttAPI is the k6 extension implementing the Mqtt api
 type MqttAPI struct { //nolint:revive
-	vu modules.VU
+	vu              modules.VU
+	initEnvironment *common.InitEnvironment
 }
 
 // NewModuleInstance implements the modules.Module interface and returns
 // a new instance for each VU.
 func (*RootModule) NewModuleInstance(vu modules.VU) modules.Instance {
-	return &MqttAPI{vu: vu}
+	return &MqttAPI{vu: vu, initEnvironment: vu.InitEnv()}
 }
 
 // Exports exposes the given object in ts

--- a/stats.go
+++ b/stats.go
@@ -3,7 +3,7 @@ package mqtt
 import (
 	"errors"
 
-	"go.k6.io/k6/js/modules"
+	"go.k6.io/k6/js/common"
 	"go.k6.io/k6/metrics"
 )
 
@@ -27,10 +27,9 @@ type mqttMetricsLabels struct {
 }
 
 // registerMetrics registers the metrics for the mqtt module in the metrics registry
-func registerMetrics(vu modules.VU, labels mqttMetricsLabels) (mqttMetrics, error) {
+func registerMetrics(env *common.InitEnvironment, labels mqttMetricsLabels) (mqttMetrics, error) {
 	var err error
 	m := mqttMetrics{}
-	env := vu.InitEnv()
 	if env == nil {
 		return m, errors.New("missing env")
 	}


### PR DESCRIPTION
Allows the client to be created in the VU phase rather than requiring the init phase env.